### PR TITLE
Authentication/auth skeleton

### DIFF
--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -46,6 +46,15 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator-maven-plugin</artifactId>
             <version>5.0.1</version>

--- a/authentication-service/pom.xml
+++ b/authentication-service/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>spring-plugin-core</artifactId>
             <version>2.0.0.RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.5.2</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/authentication-service/src/main/java/agh/fis/authentication/controller/AuthenticationController.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/controller/AuthenticationController.java
@@ -3,10 +3,14 @@ package agh.fis.authentication.controller;
 import agh.fis.authentication.api.AuthenticationApi;
 import agh.fis.authentication.model.AuthenticationRequest;
 import agh.fis.authentication.model.AuthenticationResponse;
+import agh.fis.authentication.service.JwtTokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -15,17 +19,29 @@ import javax.validation.Valid;
 public class AuthenticationController implements AuthenticationApi {
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);
 
-    @GetMapping("/")
-    public String hello(AuthenticationRequest authenticationRequest) {
-        logger.info("Get on authentication /");
-        return "Hello Authentication";
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenService jwtTokenService;
+
+    public AuthenticationController(AuthenticationManager authenticationManager, JwtTokenService jwtTokenService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenService = jwtTokenService;
     }
 
     @Override
     public ResponseEntity<AuthenticationResponse> authenticate(@Valid AuthenticationRequest authRequest) {
+
+        Authentication authentication = authenticationManager.authenticate(createAuthenticationToken(authRequest));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String token = jwtTokenService.generateToken(authentication);
+
         return ResponseEntity.ok(
                 new AuthenticationResponse()
-                        .token("token")
+                        .token(token)
         );
+    }
+
+    private Authentication createAuthenticationToken(AuthenticationRequest request) {
+        return new UsernamePasswordAuthenticationToken(request.getLogin(), request.getPassword());
     }
 }

--- a/authentication-service/src/main/java/agh/fis/authentication/controller/HelloController.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/controller/HelloController.java
@@ -1,0 +1,18 @@
+package agh.fis.authentication.controller;
+
+import agh.fis.authentication.model.AuthenticationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    private static final Logger logger = LoggerFactory.getLogger(HelloController.class);
+
+    @GetMapping("/")
+    public String hello(AuthenticationRequest authenticationRequest) {
+        return "Hello Authentication";
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/security/configuration/Beans.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/configuration/Beans.java
@@ -1,0 +1,28 @@
+package agh.fis.authentication.security.configuration;
+
+import agh.fis.authentication.security.filter.JwtFilter;
+import agh.fis.authentication.service.JwtTokenService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class Beans {
+
+    private final JwtTokenService tokenService;
+
+    public Beans(JwtTokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
+
+    @Bean
+    public JwtFilter jwtAuthenticationFilter() {
+        return new JwtFilter(tokenService);
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/security/configuration/SecurityConfiguration.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/configuration/SecurityConfiguration.java
@@ -17,7 +17,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
-    public static final String LOGIN_PATH = "/authenticate/**";
+    private static final String LOGIN_PATH = "/authenticate/**";
+    private static final String API_DOCS = "/doc/**";
     private final PasswordEncoder passwordEncoder;
     private final UserDetailsService userDetailsService;
     private final JwtFilter jwtFilter;
@@ -53,6 +54,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .antMatchers(LOGIN_PATH)
+                .permitAll()
+                .antMatchers(API_DOCS)
                 .permitAll()
                 .anyRequest()
                 .authenticated();

--- a/authentication-service/src/main/java/agh/fis/authentication/security/configuration/SecurityConfiguration.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/configuration/SecurityConfiguration.java
@@ -1,0 +1,66 @@
+package agh.fis.authentication.security.configuration;
+
+import agh.fis.authentication.security.filter.JwtFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    public static final String LOGIN_PATH = "/authenticate/**";
+    private final PasswordEncoder passwordEncoder;
+    private final UserDetailsService userDetailsService;
+    private final JwtFilter jwtFilter;
+
+    public SecurityConfiguration(PasswordEncoder passwordEncoder, UserDetailsService userDetailsService, JwtFilter jwtFilter) {
+        this.passwordEncoder = passwordEncoder;
+        this.userDetailsService = userDetailsService;
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder builder) throws Exception {
+        builder
+                .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder);
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .cors()
+                .and()
+                .csrf()
+                .disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers(LOGIN_PATH)
+                .permitAll()
+                .anyRequest()
+                .authenticated();
+
+        configureJwtFilter(http);
+    }
+
+    private void configureJwtFilter(HttpSecurity http) {
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/security/filter/JwtFilter.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/filter/JwtFilter.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public class JwtFilter extends OncePerRequestFilter {
 
-    public static final String BEARER_TOKEN = "Bearer ";
+    private static final String BEARER_TOKEN = "Bearer ";
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final JwtTokenService tokenService;
 

--- a/authentication-service/src/main/java/agh/fis/authentication/security/filter/JwtFilter.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/filter/JwtFilter.java
@@ -1,0 +1,62 @@
+package agh.fis.authentication.security.filter;
+
+import agh.fis.authentication.service.JwtTokenService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+
+public class JwtFilter extends OncePerRequestFilter {
+
+    public static final String BEARER_TOKEN = "Bearer ";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private final JwtTokenService tokenService;
+
+    public JwtFilter(JwtTokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            getJwtFromRequest(httpServletRequest)
+                    .filter(this::isTokenValid)
+                    .flatMap(tokenService::getUserFromToken)
+                    .map(this::createAuthentication)
+                    .ifPresent(this::updateSecurityContext);
+        } catch (Exception ex) {
+            // TODO log
+        }
+
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+
+    private Authentication createAuthentication(UserDetails userDetails) {
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    private boolean isTokenValid(String token) {
+        return StringUtils.hasText(token) && tokenService.validateToken(token);
+    }
+
+    private void updateSecurityContext(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private Optional<String> getJwtFromRequest(HttpServletRequest httpServletRequest) {
+        return Optional.of(httpServletRequest)
+                .map(request -> request.getHeader(AUTHORIZATION_HEADER))
+                .filter(StringUtils::hasText)
+                .filter(token -> token.startsWith(BEARER_TOKEN))
+                .map(x -> x.substring(BEARER_TOKEN.length()));
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/security/jwt/JwtGenerator.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/jwt/JwtGenerator.java
@@ -1,0 +1,32 @@
+package agh.fis.authentication.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtGenerator {
+
+    //TODO move to properties
+    private static final int EXPIRE = 600000;
+    private static final String SECRET = "secret";
+
+    public String createToken(Authentication authentication) {
+        UserDetails user = (UserDetails) authentication.getPrincipal();
+
+        Date now = new Date();
+        //TODO think about expiration date
+        Date expiryDate = new Date(now.getTime() + EXPIRE);
+
+        return Jwts.builder()
+                .setSubject(user.getUsername()) // TODO create custom UserDetails and use ID
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, SECRET)
+                .compact();
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/security/jwt/JwtParser.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/security/jwt/JwtParser.java
@@ -1,0 +1,24 @@
+package agh.fis.authentication.security.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtParser {
+
+    //TODO move to properties
+    private final static String SECRET = "secret";
+
+    //TODO catch all exceptions ie expired token
+    public boolean validate(String token) {
+        return true;
+    }
+
+    public String retrieveSubject(String token) {
+        return Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/service/JwtTokenService.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/service/JwtTokenService.java
@@ -1,0 +1,39 @@
+package agh.fis.authentication.service;
+
+import agh.fis.authentication.security.jwt.JwtGenerator;
+import agh.fis.authentication.security.jwt.JwtParser;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class JwtTokenService {
+    private static final String SECRET = "secret";
+
+    private final JwtGenerator jwtGenerator;
+    private final JwtParser jwtParser;
+    private final UserDetailsService userDetailsService;
+
+    public JwtTokenService(JwtGenerator jwtGenerator, JwtParser jwtParser, UserDetailsService userDetailsService) {
+        this.jwtGenerator = jwtGenerator;
+        this.jwtParser = jwtParser;
+        this.userDetailsService = userDetailsService;
+    }
+
+    public String generateToken(Authentication authentication) {
+        return jwtGenerator.createToken(authentication);
+    }
+
+    public Optional<UserDetails> getUserFromToken(String token) {
+        return Optional.ofNullable(token)
+                .map(jwtParser::retrieveSubject)
+                .map(userDetailsService::loadUserByUsername);
+    }
+
+    public boolean validateToken(String token) {
+        return jwtParser.validate(token);
+    }
+}

--- a/authentication-service/src/main/java/agh/fis/authentication/service/UserDetailsServiceImpl.java
+++ b/authentication-service/src/main/java/agh/fis/authentication/service/UserDetailsServiceImpl.java
@@ -1,0 +1,28 @@
+package agh.fis.authentication.service;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private static final String IN_MEMORY_USER = "sampleuser";
+    private static final String IN_MEMORY_PASSWORD = "samplepassword";
+    private static final String IN_MEMORY_ROLE = "ADMIN";
+
+    @Override
+    //TODO implementation
+    public UserDetails loadUserByUsername(String s) throws UsernameNotFoundException {
+        if (IN_MEMORY_USER.equals(s)) {
+            return User.withUsername(IN_MEMORY_USER)
+                    .password(IN_MEMORY_PASSWORD)
+                    .roles(IN_MEMORY_ROLE)
+                    .build();
+        } else throw new UsernameNotFoundException("");
+    }
+}

--- a/authentication-service/src/main/resources/application.properties
+++ b/authentication-service/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.cloud.kubernetes.discovery.all-namespaces=true
 
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=ALWAYS
+
+springdoc.api-docs.path=/doc/api
+springdoc.swagger-ui.path=/doc/swagger-ui.html


### PR DESCRIPTION
-  added basic skeleton with mock-like implementation for 1 in-memory user (jwt generation, jwt parsing, authentication filter, user details service)
- added swagger doc endpoint

// Sample use:
1. post {"login": "sampleuser","password": "samplepassword"} on "/authenticate" endpoint
2. copy token
3. get on "/" with bearer token from previous step

Swagger endpoints:
/doc/api - openAPI file
/doc/swagger-ui.html  - UI doc
