### PR TITLE
Add strict param to auth route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -108,6 +108,7 @@ const routeItems: Array<RouteItem> = [
       </>
     ),
     authenticated: null,
+    exact: false,
   },
 ];
 


### PR DESCRIPTION
It is my oversight during rebase - strict param in `routeItems` becomes required but I forgot to add it which results in app crash.